### PR TITLE
Use LTS release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.10
+FROM ubuntu:14.04
 
 MAINTAINER potch8228 pikopiko28@gmail.com
 


### PR DESCRIPTION
Ubuntu 14.10 End up support in July 2015. 
https://wiki.ubuntu.com/Releases
I recommend you to use LTS release.
